### PR TITLE
Added support for date string formats not recognized by moment

### DIFF
--- a/moment/nrmoment.js
+++ b/moment/nrmoment.js
@@ -166,6 +166,17 @@ module.exports = function(RED) {
         mDT = moment.tz(inp, null, true, node.inTz)
       }
 
+      // Fallback to JS built-in Date parsing, if not recognized by moment
+      if (!mDT.isValid()) {
+        var dtm = new Date(inp);
+        if (dtm === 'Invalid Date') {
+          node.warn('Unrecognized date string format => ' + inp);
+        }
+        else {
+          mDT = moment(dtm);
+        }
+      }
+
       // Adjust the date for input hacks if needed (e.g. input was "yesterday" or "tommorow")
       if ( dtHack !== '' ) { mDT.add(dtHack); }
 


### PR DESCRIPTION
Fallback to new Date(inp) when the date string is non-standard,
like this output from the file stat() function:
2017-12-12 16:03:51.832427000 -0400
as well as the Twitter API default time string:
Mon Jan 08 21:24:37 +0000 2018
